### PR TITLE
add putAll procedure

### DIFF
--- a/src/picostdlib/gpio.nim
+++ b/src/picostdlib/gpio.nim
@@ -113,7 +113,15 @@ proc getAll*: uint32 {.importC: "gpio_get_all".}
   ## Get raw value of all Gpios. 
   ## 
   ## **Returns:** uint32 of raw Gpio values, as bits 0-29  
-
+  
+proc putAll*(value: uint32) {.importC: "gpio_put_all".}
+  ## He writes the entire register (all bits) in one time only
+  ##
+  ## **Parameters:**
+  ##
+  ## =======================================  ====== 
+  ## **uint32**
+  
 proc put*(gpio: Gpio, value: Value){.importC: "gpio_put".}
   ## Drive a single Gpio high/low. 
   ## 
@@ -167,6 +175,7 @@ proc enableIrq*(gpio: Gpio, events: set[IrqLevel], enabled: bool){.importC: "gpi
 
 proc enableIrqWithCallback*(gpio: Gpio, events: set[IrqLevel], enabled: bool, event: IrqCallback){.
     importC: "gpio_set_irq_enabled_with_callback".}
+
 
 {.pop.}
 

--- a/src/picostdlib/time.nim
+++ b/src/picostdlib/time.nim
@@ -48,7 +48,17 @@ proc getTime*: AbsoluteTime {.importC:"get_absolute_time".}
   ## sampled during the call.
   ## 
   ## **Returns:** the absolute time (now) of the hardware timer
-
+# --------- test -------------------
+proc absoluteTimeDiff*(time1, time2: AbsoluteTime): int64 {.importc: "absolute_time_diff_us".}
+ ## Return a representation of the current time.
+ ##
+ ## Returns an opaque high fidelity representation of the current time sampled during the call.
+ ## **Parameters:**
+ ##
+ ## ========= =======
+ ## **time1, time2## absolute time of the hardware
+ ## ============
+ ## **Returns:** uint64
 proc addAlarm*(time: AbsoluteTime, callBack: AlarmCallback, data: pointer, fireIfPast: bool): AlarmId{.importc: "add_alarm_at".}
   ## Add an alarm callback to be called at a specific time. 
   ## 


### PR DESCRIPTION
Putall () allows you to write the entire register by providing an Uint32. Much more comfortable than providing every single value for each individual bit. In addition you can use the bit meat and shift (right left of the bits)