### PR TITLE
Include existing nimbase.h file from nim lib dir at compile-time

### DIFF
--- a/picostdlib.nimble
+++ b/picostdlib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.1"
+version       = "0.3.2"
 author        = "Jason"
 description   = "Raspberry Pi Pico stdlib bindings/libraries"
 license       = "MIT"
@@ -13,6 +13,6 @@ installDirs = @["template"]
 
 # Dependencies
 
-requires "nim >= 1.2.0"
+requires "nim >= 1.6.0"
 requires "https://github.com/casey-SK/commandant >= 0.15.1"
 requires "https://github.com/beef331/micros"


### PR DESCRIPTION
This removes the downloading / copying of the `nimbase.h` file when creating a project with `piconim init`. Instead, we add a CMake directive so that the `nim/lib` dir is passed as an include search path to gcc.

Why:

- No need to mess around with downloading the correct nimbase file at project creation time, or asking the user to specify the path.
- The nimbase file will always correspond to the nim compiler that is being used for the build. We do this by running nim at compile time and calling `getCurrentCompilerExe`. Should prevent issues with nimbase if version incompatibilities are introduced in future nim versions.

This is implemented by piggybacking onto the same cmake include file that is generated at runtime (for the pico-sdk includes). I moved and renamed stuff a bit in the piconim code in order to reflect this. The advantage is that existing projects keep working with new piconim, because we don't need to add a new include to the base CMakeLists file.

I bumped the min required Nim compiler to 1.6.0, for two reasons:
  - The `-mm` switch that was already included in the project template is not compatible with prior versions, that used `-gc`.
  - `getCurrentCompilerExe()` also doesn't exist in prior versions

Finally, bumped nimble patch version.