### PR TITLE
Suppress gcc warnings when compiling nim sources

### DIFF
--- a/src/template/csource/CMakeLists.txt
+++ b/src/template/csource/CMakeLists.txt
@@ -17,8 +17,12 @@ set(Imports imports.cmake)
 if(EXISTS "../${Imports}")
 
 # add program file(s)
-file(GLOB MyCSources build/nimcache/*.c)
-add_executable(blink ${MyCSources})
+file(GLOB NimSources build/nimcache/*.c)
+
+# Suppress gcc warnings for nim-generated files
+set_source_files_properties(${NimSources} PROPERTIES COMPILE_OPTIONS "-w")
+
+add_executable(blink ${NimSources})
 
 # Add directory containing this CMakeLists file to include search path.
 # This is required so that the nimbase.h file is found. Other headers


### PR DESCRIPTION
Resolves #55

1. With Nim 1.6.8, the warnings appear no matter whether `--cpu:arm` is passed  on the command line or not. I assume this is a fix to harmonize behavior between config and command line flags.

2. I asked Araq on Discord, and the incompatible pointer type warnings are expected and not an issue.

3. Nim itself, when it invokes gcc, always passes the `-w` flag which suppresses all warnings.

Therefore, I propose to imitate the Nim compiler behavior and pass `-w` to gcc for all Nim-generated C files. This is implemented via a `set_source_file_properties` in the CMake file and only affects the Nim-generated sources, not the other (pico SDK, external libs, etc) C source files.

Yes, I could have lived with warnings, but I like my terminal output clean and pretty looking 🙃. 