### PR TITLE
Fix tinyusb example CMakeLists

### DIFF
--- a/examples/tinyusb/CMakeLists.txt
+++ b/examples/tinyusb/CMakeLists.txt
@@ -1,30 +1,43 @@
 cmake_minimum_required(VERSION 3.13)
 
-# initialize the SDK based on PICO_SDK_PATH
+# initialize pico-sdk from GIT
+# (note this can come from environment, CMake cache etc)
+#set(PICO_SDK_FETCH_FROM_GIT on)
 
+# pico_sdk_import.cmake is a single file copied from this SDK
 # note: this must happen before project()
 include(pico_sdk_import.cmake)
 
 project(tinyusb)
-
 # initialize the Raspberry Pi Pico SDK
 pico_sdk_init()
 
-# add program file(s)
-file(GLOB MyCSources *.c)
-add_executable(tinyusb)
+set(Imports imports.cmake)
 
-target_sources(tinyusb PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src/usb_descriptors.c
-        ${MyCSources}
-        )
+if(EXISTS "../${Imports}")
+
+# add program file(s)
+file(GLOB NimSources build/nimcache/*.c)
+
+# Suppress gcc warnings for nim-generated files
+set_source_files_properties(${NimSources} PROPERTIES COMPILE_OPTIONS "-w")
+
+# Add Nim-generated files AND the usb_descriptors.c file to the build
+add_executable(tinyusb ${NimSources} ${CMAKE_CURRENT_LIST_DIR}/../src/usb_descriptors.c)
 
 # Make sure TinyUSB can find tusb_config.h
 target_include_directories(tinyusb PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../src)
 
-# pull in our pico_stdlib which pulls in commonly used features
-# hardware_adc tinyusb_device tinyusb_board Currently supported.
-target_link_libraries(tinyusb pico_stdlib hardware_adc tinyusb_board tinyusb_device)
+# Add directory containing this CMakeLists file to include search path.
+# This is required so that the nimbase.h file is found. Other headers
+# required for a project can also be placed here.
+target_include_directories(tinyusb PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
+include(${Imports}) # Include our generated file
+link_imported_libs(tinyusb) # call our generated function to import all libs we're using
+
+# Link tinyusb device libs
+target_link_libraries(tinyusb tinyusb_device tinyusb_board)
 
 # Note: since we create a custom tinyusb device, USB stdio must be disabled
 pico_enable_stdio_usb(tinyusb 0)
@@ -35,3 +48,4 @@ pico_add_extra_outputs(tinyusb)
 
 # add url via pico_set_program_url
 pico_set_program_url(tinyusb 1)
+endif()

--- a/examples/tinyusb/README.md
+++ b/examples/tinyusb/README.md
@@ -19,7 +19,7 @@ included with this example for this purpose.
 Follow these instructions to build the example:
 
   1. Run `piconim init tinyusb` to create a new pico project.
-  
+
   2. Copy the files `tinyusb.nim`, `usb_descriptors.c` and `tusb_config.h`
      provided in this example to the `src` directory of the project (overwrite
      the existing nim file created by piconim).
@@ -27,4 +27,4 @@ Follow these instructions to build the example:
   4. Replace the CMakeLists.txt file in the `csource` directory of the project
      with the CMakeLists.txt file included with this example.
 
-  5. run `piconim build tinyusb.nim`.
+  5. run `piconim build tinyusb`.


### PR DESCRIPTION
Update CMakeLists file from the template. The file had not been updated
when some changes were made to the piconim build process:

- Nim-generated C files going to csource/build/Nimcache instead of
  csource/build

- The auto-generated device imports

Note: tinyusb_device is still manually added to target_link_libraries. Need to
add it to the auto-generated imports process in piconim.

@beef331 FYI but I'll self-merge this one