### PR TITLE
Fixing some windows compatibility issues

### DIFF
--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -144,8 +144,12 @@ proc genCMakeInclude(projectName: string) =
   let strLibs = getPicoLibs()
 
   # include Nim lib path for nimbase.h
-  let nimLibPath = getNimLibPath()
-
+  
+  when defined(windows):
+    let nimLibPath = getNimLibPath().replace("\\", "\\\\")
+  else:
+    let nimLibPath = getNimLibPath()
+  
   writeFile(importPath, fmt(cMakeIncludeTemplate))
 
 proc builder(program: string, output = "") =
@@ -169,7 +173,9 @@ proc builder(program: string, output = "") =
   when not defined(windows):
     discard execCmd("touch csource/CMakeLists.txt")
   else:
-    discard execCmd("copy /b csource/CMakeLists.txt +,,")
+    discard execCmd("cmd /c \"type csource\\CMakeLists.txt > csource\\CMakeLists.txt_\"")
+    discard execCmd("cmd /c \"del csource\\CMakeLists.txt\"")
+    discard execCmd("cmd /c \"move csource\\CMakeLists.txt_ csource\\CMakeLists.txt\"")
   # run make
   discard execCmd("make -C csource/build")
 

--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -145,11 +145,12 @@ proc genCMakeInclude(projectName: string) =
 
   # include Nim lib path for nimbase.h
   
-  when defined(windows):
-    let nimLibPath = getNimLibPath().replace("\\", "\\\\")
-  else:
-    let nimLibPath = getNimLibPath()
-  
+  let nimLibPath =
+    when defined(windows):
+      getNimLibPath().replace("\\", "\\\\")
+    else:
+      getNimLibPath()
+
   writeFile(importPath, fmt(cMakeIncludeTemplate))
 
 proc builder(program: string, output = "") =


### PR DESCRIPTION
I ran into a couple of issues running this on Windows 10. The first was file formatting with non-escaped backslashes in the path. The second was with the "copy" command not actually being a discoverable program in my case. It's an applet in the terminal programs. It also doesn't appear to actually alter the creation time for me. The only solution I found is ugly but it works.