### PR TITLE
Use nimble dump to find the lib path

### DIFF
--- a/picostdlib.nimble
+++ b/picostdlib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.2"
+version       = "0.3.3"
 author        = "Jason"
 description   = "Raspberry Pi Pico stdlib bindings/libraries"
 license       = "MIT"

--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -99,17 +99,26 @@ proc getLinkedLib(fileName: string): set[LinkableLib] =
     else:
       break
 
+proc containsNimbaseh(dir: string): bool =
+  for (kind, path) in dir.walkDir:
+    if kind in {pcFile, pcLinkToFile} and path.extractFilename == "nimbase.h":
+      return true
+
 proc getNimLibPath: string =
   let (nimOutput, nimExitCode) = execCmdEx(
-    "nim --verbosity:0 --eval:\"import std/os; echo getCurrentCompilerExe()\"",
-    options={poUsePath}
+    "nim dump", options={poUsePath, poStdErrToStdOut}
   )
 
   if nimExitCode != 0:
     echo nimOutput
     picoError fmt"Error while trying to locate nim executable (exit code {nimExitCode})"
 
-  result = nimOutput.parentDir.parentDir / "lib"
+  for ln in nimOutput.splitLines:
+    if "lib" in ln and dirExists(ln) and ln.containsNimbaseh:
+      return ln
+
+  # If not found for some reason
+  picoError "Could not find the Nim lib path"
 
 const cMakeIncludeTemplate = """
 # This is a generated file do not modify it, 'piconim' makes it every run.

--- a/src/piconim.nim
+++ b/src/piconim.nim
@@ -100,11 +100,14 @@ proc getLinkedLib(fileName: string): set[LinkableLib] =
       break
 
 proc containsNimbaseh(dir: string): bool =
+  ## Check if dir contains a file named nimbase.h
   for (kind, path) in dir.walkDir:
     if kind in {pcFile, pcLinkToFile} and path.extractFilename == "nimbase.h":
       return true
 
 proc getNimLibPath: string =
+  ## Find the Nim "lib" path, which contains the nimbase.h file, using the
+  ## "nim dump" command.
   let (nimOutput, nimExitCode) = execCmdEx(
     "nim dump", options={poUsePath, poStdErrToStdOut}
   )


### PR DESCRIPTION
Background: https://forum.nim-lang.org/t/9895

The way `getNimLibPath` was implemented (by me) worked for choosenim installs (windows or linux) or "native" nim installs on windows, but failed for "native" package manager installs of Nim on Linux, because `nim` is usually in `/usr/bin` while `nimbase.h` gets placed in `/usr/lib/nim`.

This PR implements elcritch's idea of using `nim dump` instead. I added some extra checks for robustness (check that what we're returning is actually a directory and that it contains a file named nimbase.h).